### PR TITLE
Simplify branch folder structure

### DIFF
--- a/lib/counter/counter.dart
+++ b/lib/counter/counter.dart
@@ -2,3 +2,4 @@ class Counter {
   final int value;
   const Counter(this.value);
 }
+

--- a/lib/counter/counter_local_datasource.dart
+++ b/lib/counter/counter_local_datasource.dart
@@ -1,4 +1,4 @@
-import '../models/counter_model.dart';
+import 'package:counter/counter/counter_model.dart';
 
 abstract class CounterLocalDataSource {
   CounterModel getCounter();
@@ -17,3 +17,4 @@ class CounterLocalDataSourceImpl implements CounterLocalDataSource {
     return _counter;
   }
 }
+

--- a/lib/counter/counter_model.dart
+++ b/lib/counter/counter_model.dart
@@ -1,4 +1,4 @@
-import '../../domain/entities/counter.dart';
+import 'package:counter/counter/counter.dart';
 
 class CounterModel extends Counter {
   const CounterModel(int value) : super(value);
@@ -9,3 +9,4 @@ class CounterModel extends Counter {
 
   Counter toEntity() => Counter(value);
 }
+

--- a/lib/counter/counter_notifier.dart
+++ b/lib/counter/counter_notifier.dart
@@ -1,8 +1,7 @@
 import 'package:flutter/material.dart';
-
-import '../../domain/entities/counter.dart';
-import '../../domain/usecases/increment_counter.dart';
-import '../../../../core/usecase.dart';
+import 'package:counter/counter/counter.dart';
+import 'package:counter/counter/increment_counter.dart';
+import 'package:counter/usecase.dart';
 
 class CounterNotifier extends ChangeNotifier {
   Counter _counter = const Counter(0);
@@ -17,3 +16,4 @@ class CounterNotifier extends ChangeNotifier {
     notifyListeners();
   }
 }
+

--- a/lib/counter/counter_repository.dart
+++ b/lib/counter/counter_repository.dart
@@ -1,6 +1,7 @@
-import '../entities/counter.dart';
+import 'package:counter/counter/counter.dart';
 
 abstract class CounterRepository {
   Counter getCounter();
   Counter increment();
 }
+

--- a/lib/counter/counter_repository_impl.dart
+++ b/lib/counter/counter_repository_impl.dart
@@ -1,6 +1,6 @@
-import '../../domain/entities/counter.dart';
-import '../../domain/repositories/counter_repository.dart';
-import '../datasources/counter_local_datasource.dart';
+import 'package:counter/counter/counter.dart';
+import 'package:counter/counter/counter_local_datasource.dart';
+import 'package:counter/counter/counter_repository.dart';
 
 class CounterRepositoryImpl implements CounterRepository {
   final CounterLocalDataSource dataSource;
@@ -13,3 +13,4 @@ class CounterRepositoryImpl implements CounterRepository {
   @override
   Counter increment() => dataSource.increment();
 }
+

--- a/lib/counter/increment_counter.dart
+++ b/lib/counter/increment_counter.dart
@@ -1,6 +1,6 @@
-import '../../../../core/usecase.dart';
-import '../entities/counter.dart';
-import '../repositories/counter_repository.dart';
+import 'package:counter/usecase.dart';
+import 'package:counter/counter/counter.dart';
+import 'package:counter/counter/counter_repository.dart';
 
 class IncrementCounter implements UseCase<Counter, NoParams> {
   final CounterRepository repository;
@@ -12,3 +12,4 @@ class IncrementCounter implements UseCase<Counter, NoParams> {
     return repository.increment();
   }
 }
+

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,9 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import 'features/counter/data/datasources/counter_local_datasource.dart';
-import 'features/counter/data/repositories/counter_repository_impl.dart';
-import 'features/counter/domain/usecases/increment_counter.dart';
-import 'features/counter/presentation/provider/counter_notifier.dart';
+import 'package:counter/counter/counter_local_datasource.dart';
+import 'package:counter/counter/counter_repository_impl.dart';
+import 'package:counter/counter/increment_counter.dart';
+import 'package:counter/counter/counter_notifier.dart';
 
 void main() {
   runApp(const CounterApp());

--- a/lib/usecase.dart
+++ b/lib/usecase.dart
@@ -3,3 +3,4 @@ abstract class UseCase<Type, Params> {
 }
 
 class NoParams {}
+


### PR DESCRIPTION
Simplify the project's folder structure by flattening `lib/features/counter` into `lib/counter` and moving `lib/core/usecase.dart` to `lib/usecase.dart` to reduce complexity.

---
<a href="https://cursor.com/background-agent?bcId=bc-557a008c-cc52-44a2-8f60-1120d4164cfa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-557a008c-cc52-44a2-8f60-1120d4164cfa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

